### PR TITLE
Fix problem with profile saving, add APNS proxy support and make micromdm easily testable with docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,11 +15,15 @@ RUN make
 FROM alpine:latest
 
 RUN apk --update add ca-certificates git
+RUN apk add openssl
+
+RUN mkdir repo
 RUN mkdir /data; chmod 777 /data
 COPY --from=builder /go/src/github.com/micromdm/micromdm/build/linux/micromdm /usr/bin/
 COPY --from=builder /go/src/github.com/micromdm/micromdm/build/linux/mdmctl /usr/bin/
 
-COPY docker-entrypoint.sh /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+RUN DNSNAME=me.home.local;  (cat /etc/ssl/openssl.cnf ; printf "\n[SAN]\nsubjectAltName=DNS:$DNSNAME\n") | openssl req -new -newkey rsa:2048 -days 365 -nodes -x509 -sha256 -keyout server.key -out server.crt -subj "/CN=$DNSNAME" -reqexts SAN -extensions SAN -config /dev/stdin
+RUN sh -c 'echo "127.0.0.1 me.home.local" >> /etc/hosts'
+
 EXPOSE 8080 8443
 CMD ["micromdm", "serve"]

--- a/README.md
+++ b/README.md
@@ -23,3 +23,24 @@ High level overview of the API used for scheduling device actions and processing
 To help with development, start by reading the [CONTRIBUTING](./CONTRIBUTING.md) document, which has relevant resources. 
 
 For a local development environment, or a demo setup, the [ngrok guide](./tools/ngrok/README.md), is the best resource to get something working.  
+
+
+
+# MySQL support
+This version of MicroMDM can be run with Mysql support in place of default BoltDB database
+
+## Test MicroMDM with Mysql
+As root, Add your IP to your hosts file (MySQL don"t accept localhost connexions for users)
+>echo $(hostname -I | cut -d" " -f1)" me.home.local" >>/etc/hosts
+
+Get official MySQL docker image
+>docker-compose -f docker-compose-dev.yaml pull db
+
+Build micromdm with MySQL support (golang and alpine official docker images will be pulled)
+>docker-compose -f docker-compose-dev.yaml build
+
+Start MySQL and MicroMDM containers
+>docker-compose -f docker-compose-dev.yaml up
+
+Enrollement interface should now be available at this address (skip self signed certifcate warnings):
+>https://me.home.local:3478/

--- a/docker-compose-dev.yaml
+++ b/docker-compose-dev.yaml
@@ -1,7 +1,8 @@
-version: "2"
+version: "2.1"
 
 services:
   db:
+    network_mode: host
     image: mysql
     command: --default-authentication-plugin=mysql_native_password
     environment:
@@ -11,3 +12,30 @@ services:
       MYSQL_PASSWORD: micromdm
     ports:
       - 3306:3306
+    healthcheck:
+      test: mysqladmin ping -h 127.0.0.1 -u $$MYSQL_USER --password=$$MYSQL_PASSWORD 
+  micromdm:
+    network_mode: host
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: micromdm
+    environment:
+      MICROMDM_RDBMS: mysql
+      MICROMDM_RDBMS_DATABASE: micromdm
+      MICROMDM_RDBMS_USERNAME: micromdm
+      MICROMDM_RDBMS_PASSWORD: micromdm
+      MICROMDM_RDBMS_HOST: 127.0.0.1
+      MICROMDM_RDBMS_PORT: 3306            
+      MICROMDM_API_KEY: MySuperSecretKey
+      MICROMDM_HTTP_ADDR: ":3478"
+      MICROMDM_TLS: "true"
+      MICROMDM_SERVER_URL: "https://me.home.local:3478/"
+      MICROMDM_FILE_REPO: ./repo
+      MICROMDM_TLS_CERT: server.crt
+      MICROMDM_TLS_KEY: server.key
+    ports:
+      - 3478:3478
+    depends_on:
+      db:
+        condition: service_healthy

--- a/platform/apns/service.go
+++ b/platform/apns/service.go
@@ -136,6 +136,7 @@ func newClient(cert tls.Certificate) (*http.Client, error) {
 	}
 	config.BuildNameToCertificate()
 	transport := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
 		TLSClientConfig: config,
 		IdleConnTimeout: 90 * time.Second,
 	}


### PR DESCRIPTION
Hi,

Here is a fix for profile saving that seem's to not work
and always return an error if profile does not exists, since err is also declared in "if" statement.

Note, this fix has only been tested with my micromdm tool to migrate from Boltdb to MySQL Db (see my Github space), since I don't have any recent Mac to test it.

Regards,
SixK