### PR TITLE
Add missing filter to get devices filtered on serial number

### DIFF
--- a/platform/device/mysql/mysql.go
+++ b/platform/device/mysql/mysql.go
@@ -255,6 +255,7 @@ func (d *Mysql) List(ctx context.Context, opt device.ListDevicesOption) ([]devic
 		PlaceholderFormat(sq.Question).
 		Select(columns()...).
 		From(tableName).
+		Where(sq.Or{sq.Expr("0=?",len(opt.FilterSerial)), sq.Eq{"serial_number": opt.FilterSerial}}).
 		ToSql()
 		
 	if err != nil {


### PR DESCRIPTION
Add missing filter compared to BoltDb version to get devices list filtered on serial_number:
This modification can be tested with the following commands:
cd tools/api

create env.txt file with the following values:
SERVER_URL=https://localhost:3478
API_TOKEN=MySuperSecretKey
CURL_OPTS="-k -vvv"

export MICROMDM_ENV_PATH=./env.txt
bash ./get_devices
This script should get all devices in database. 

Then modify get_devices script like this (change serial number by an existing one in your MySQL devices table) :
curl $CURL_OPTS -X POST --data-binary '{"filter_serial":["Z1ZZ2732GHY4"]}' -s -u "micromdm:$API_TOKEN" "$SERVER_URL/$endpoint"

This should return only the device with the "Z1ZZ2732GHY4" serial number. (actually all devices are returned since no filter is applied)
